### PR TITLE
entity.py syntax error with if statements

### DIFF
--- a/Bomberman/entity.py
+++ b/Bomberman/entity.py
@@ -27,7 +27,7 @@ class PositionalEntity(Entity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (self.x, self.y) == (other.x, other.y)
 
     def __ne__(self, other):
@@ -74,7 +74,7 @@ class MovableEntity(PositionalEntity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (super().__eq__(other) and
                 (self.dx, self.dy) == (other.dx, other.dy))
 
@@ -104,7 +104,7 @@ class TimedEntity(Entity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return self.timer == other.timer
 
     def __ne__(self, other):
@@ -132,7 +132,7 @@ class AIEntity(Entity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return self.name == other.name
 
     def __ne__(self, other):
@@ -153,7 +153,7 @@ class OwnedEntity(Entity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return self.owner == other.owner
 
     def __ne__(self, other):
@@ -176,7 +176,7 @@ class BombEntity(PositionalEntity, TimedEntity, OwnedEntity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (super(PositionalEntity, self).__eq__(other) and
                 super(TimedEntity, self).__eq__(other) and
                 super(OwnedEntity, self).__eq__(other))
@@ -201,7 +201,7 @@ class ExplosionEntity(PositionalEntity, TimedEntity, OwnedEntity):
     ###################
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (super(PositionalEntity, self).__eq__(other) and
                 super(TimedEntity, self).__eq__(other) and
                 super(OwnedEntity, self).__eq__(other))
@@ -240,7 +240,7 @@ class MonsterEntity(AIEntity, MovableEntity):
         return hash((self.name, self.x, self.y))
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (super(MovableEntity, self).__eq__(other) and
                 super(AIEntity, self).__eq__(other))
 
@@ -290,7 +290,7 @@ class CharacterEntity(AIEntity, MovableEntity):
         return hash((self.name, self.x, self.y))
 
     def __eq__(self, other):
-        if(not other) return False
+        if(not other): return False
         return (self.maybe_place_bomb == other.maybe_place_bomb and
                 super(MovableEntity, self).__eq__(other) and
                 super(AIEntity, self).__eq__(other))


### PR DESCRIPTION
Several if-statements in entity.py are not properly closed with colons, causing syntax errors. This has been remedied by adding the missing colons.